### PR TITLE
Add support for improper lists to sext_eqc:comp_i.

### DIFF
--- a/test/sext_eqc.erl
+++ b/test/sext_eqc.erl
@@ -225,7 +225,9 @@ comp_l([Ha|Ta],[Hb|Tb]) ->
             comp_l(Ta, Tb);
         Other ->
             Other
-    end.
+    end;
+comp_l(A, B) -> % A or B was an improper list
+    comp_i(A, B).
 
 is_prefix(A, B) ->
     Sz = byte_size(A),


### PR DESCRIPTION
QuickCheck generated a term() that `sext_eqc:comp_i` couldn't handle with
an improper list in it.

```
1> eqc:current_counterexample().
[{[{}|<<>>],[{}]}]
```

Before

```
1> eqc:check(sext_eqc:prop_sort_hex(), [{[{}|<<>>],[{}]}]).
Failed! Reason: 
{'EXIT',{function_clause,[{sext_eqc,comp_l,[<<>>,[]]},
                          {sext_eqc,'-prop_sort_hex/0-fun-0-',1},
                          {eqc,'-f780_0/2-fun-4-',3},
                          {eqc_gen,'-f321_0/2-fun-0-',5},
                          {eqc_gen,f186_0,2},
                          {eqc_gen,'-f321_0/2-fun-0-',5},
                          {eqc_gen,f186_0,2},
                          {eqc_gen,gen,3}]}}
{[{}|<<>>],[{}]}
false
```

After

```
1> eqc:check(sext_eqc:prop_sort_hex(), [{[{}|<<>>],[{}]}]).
OK, passed the test.
true
```
