### PR TITLE
support legacy bignum encoding in arbitrary terms

### DIFF
--- a/test/sext_eqc.erl
+++ b/test/sext_eqc.erl
@@ -131,7 +131,7 @@ prop_encode() ->
 
 prop_decode_legacy_big() ->
     ?FORALL(T, big(),
-	    sext:decode(sext:legacy_encode_bignum(T)) == T).
+	    sext:decode(sext:encode(T, true)) == T).
 
 prop_encode_sb32() ->
     ?FORALL(T, term(),


### PR DESCRIPTION
adds encode/2 which takes a boolean indicating whether or not to encode bignums
using the legacy encoding. removes legacy_encode_bignum/1 since the same
functionality is supported by encode/2
