### PR TITLE
Updated sext_eqc so that it will undefine the macro QC before redefining it

### DIFF
--- a/test/sext_eqc.erl
+++ b/test/sext_eqc.erl
@@ -19,10 +19,12 @@
 %% Prefer QuickCheck, but otherwise try with Proper (some properties will
 %% have trouble under Proper - feel free to investigate).
 -ifdef(EQC).
+-undef(QC).
 -define(QC,eqc).
 -include_lib("eqc/include/eqc.hrl").
 -else.
 -ifdef(PROPER).
+-undef(QC).
 -define(QC,proper).
 -include_lib("proper/include/proper.hrl").
 -endif.


### PR DESCRIPTION
This is a change for my development environment that prevents a compile warning for redefining the macro QC.
