### PR TITLE
Deprecate esl/edown.git

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- erlang -*-
 {erl_opts, [debug_info]}.
-{deps, [{edown, ".*", {git, "git://github.com/esl/edown.git", "HEAD"}}]}.
+{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", "HEAD"}}]}.
 {src_dirs, ["examples"]}.
 {edoc_opts, [{doclet, edown_doclet},
 	     {src_path, ["src/", "examples/"]},


### PR DESCRIPTION
The esl/edown.git repository often lags the uwiger/edown.git repository.  Replace the esl/edown.git repository with the uwiger/edown.git repository.
