### PR TITLE
fix rebar.config.script

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -14,5 +14,5 @@ case IsRebar3 of
                                  {top_level_readme,
                                   {"./README.md",
                                    "http://github.com/uwiger/sext"}}]}],
-    CONFIG = CONFIG ++ Rebar2Config
+    CONFIG ++ Rebar2Config
 end.


### PR DESCRIPTION
`CONFIG = CONFIG ++ Rebar2Config` won't match