### PR TITLE
encode maps keeping keys in order.

### DIFF
--- a/src/sext.erl
+++ b/src/sext.erl
@@ -277,11 +277,11 @@ prefix_list(L) ->
 
 encode_map(M, Legacy) ->
     Sz = map_size(M),
-    maps:fold(
-      fun(K,V,Acc) ->
+    lists:foldl(
+      fun({K,V},Acc) ->
               <<Acc/binary, (encode(K, Legacy))/binary,
                 (encode(V, Legacy))/binary>>
-      end, <<?list, 1:8, Sz:32>>, M).
+      end, <<?list, 1:8, Sz:32>>, maps:to_list(M)).
 
 
 encode_binary(B)    ->


### PR DESCRIPTION
to keep maps in order, we first sort it by keys by transforming them as
list. Then we process the keys/values in order.

ex:

2> B = sext:encode(#{ a => 1, b=>1 }).
<<17,1,0,0,0,2,12,176,128,8,10,0,0,0,2,12,177,0,8,10,0,0,
  0,2>>
3> B = sext:encode(#{ b => 1, a=>1 }).
<<17,1,0,0,0,2,12,176,128,8,10,0,0,0,2,12,177,0,8,10,0,0,
  0,2>>