### PR TITLE
Add option to choose encoding for non-ASCII atoms (latin1 or utf8)

### DIFF
--- a/src/sext.erl
+++ b/src/sext.erl
@@ -35,7 +35,10 @@
 -export([pp/1]).  % for debugging only
 
 -type options() :: #{legacy => boolean(),
-                     atom_encoding => latin1 | utf8}.
+                     atom_encoding => latin1 | utf8} |
+                   boolean().
+%% legacy: boolean() - if true, encode using the old bignum format; default: false
+%% atom_encoding: latin1 | utf8 - encoding to use for atoms; default: latin1
 
 -define(rev_sext , 4).
 %%
@@ -96,6 +99,7 @@ encode(X) -> encode(X, #{}).
 %%
 %% Use only as transition support. This function will be deprecated in time.
 %% @end
+encode(X, Legacy) when is_boolean(Legacy) -> encode(X, #{legacy => Legacy});
 encode(X, Opts) when is_tuple(X)    -> encode_tuple(X, Opts);
 encode(X, Opts) when is_map(X)      -> encode_map(X, Opts);
 encode(X, Opts) when is_list(X)     -> encode_list(X, Opts);
@@ -743,6 +747,7 @@ decode_next(Elems) ->
 %% This function will raise an exception if the beginning of `Bin' is not
 %% a valid sext-encoded term.
 %% @end
+decode_next(Elems, Legacy) when is_boolean(Legacy) -> decode_next(Elems, #{legacy => Legacy});
 decode_next(<<?rev_sext,Rest/binary>>, _) -> decode_rev_sext(Rest);
 decode_next(<<?atom,Rest/binary>>, Opts) -> decode_atom(Rest, Opts);
 decode_next(<<?pid, Rest/binary>>, _) -> decode_pid(Rest);


### PR DESCRIPTION
This addresses the #40 

However it doesn't add support to `encode_prefix` / `decode_prefix`, mainly because `Legacy` option was not supported there as well. However I think I should actually add it. Maybe separate commit?
Readme should be probably updated as well.

I didn't run tests because I don't have quickcheck, but it compiles and seems to work:

```erlang
1> sext:encode('привет').
** exception error: bad argument
     in function  atom_to_binary/2
        called as atom_to_binary('привет',latin1)
        *** argument 1: contains a character not expressible in latin1
     in call from sext:encode_atom/2 (/Users/sergey.prokhorov/workspace/sext/src/sext.erl, line 411)
2> sext:encode('привет', #{atom_encoding => utf8}).
<<12,232,111,250,56,14,134,227,161,178,232,109,122,56,32,8>>
3> sext:decode(sext:encode('привет', #{atom_encoding => utf8})).
'Ð¿Ñ\200Ð¸Ð²ÐµÑ\202'
4> sext:decode(sext:encode('привет', #{atom_encoding => utf8}), #{atom_encoding => utf8}).
'привет'
```

So, what do you think?